### PR TITLE
Fix pjax toc

### DIFF
--- a/include/schema/custom/addons.json
+++ b/include/schema/custom/addons.json
@@ -17,6 +17,22 @@
         },
         "lazyload": {
             "$ref": "/custom/lazyload.json"
+        },
+        "pjax": {
+            "type": "object",
+            "description": "Enable pjax in this site (Experimental)",
+            "properties": {
+                "enable": {
+                    "type": "boolean",
+                    "description": "Total switch for PJAX supports",
+                    "default": false
+                },
+                "js": {
+                    "type": "string",
+                    "description": "The URL or CDN to load pjax.js",
+                    "default": "https://cdn.jsdelivr.net/npm/pjax@0.2.8/pjax.js"
+                }
+            }
         }
     }
 }

--- a/include/schema/custom/addons.json
+++ b/include/schema/custom/addons.json
@@ -32,7 +32,8 @@
                     "description": "The URL or CDN to load pjax.js",
                     "default": "https://cdn.jsdelivr.net/npm/pjax@0.2.8/pjax.js"
                 }
-            },
+            }
+        },
         "backstretch": {
             "$ref": "/custom/backstretch.json"
         }

--- a/layout/common/navbar.jsx
+++ b/layout/common/navbar.jsx
@@ -52,7 +52,7 @@ class Navbar extends Component {
                     </a>
                 </div>
                 <div class="navbar-menu">
-                    {Object.keys(menu).length ? <div class="navbar-start">
+                    {Object.keys(menu).length ? <div class="navbar-start" id="pjax-nav">
                         {Object.keys(menu).map(name => {
                             const item = menu[name];
                             return <a class={classname({ 'navbar-item': true, 'is-active': item.active })} href={item.url}>{name}</a>;

--- a/layout/common/navbar.jsx
+++ b/layout/common/navbar.jsx
@@ -58,7 +58,7 @@ class Navbar extends Component {
                             return <a class={classname({ 'navbar-item': true, 'is-active': item.active })} href={item.url}>{name}</a>;
                         })}
                     </div> : null}
-                    <div class="navbar-end">
+                    <div class="navbar-end" id="pjax-buttons">
                         {showToc ? <a class="navbar-item is-hidden-tablet catalogue" title={tocTitle} href="javascript:;">
                             <i class="fas fa-list-ul"></i>
                         </a> : null}

--- a/layout/common/scripts.jsx
+++ b/layout/common/scripts.jsx
@@ -34,6 +34,11 @@ module.exports = class extends Component {
             <script src="/js/yuuki/lazyload_embedded.js"></script>
         </> : null;
 
+        const defaultPjax = "https://cdn.jsdelivr.net/npm/pjax/pjax.js";
+        const pjaxScripts = addons.pjax?.enable ? <>
+            <script src={addons.pjax?.js ?? defaultPjax}></script>
+        </> : null;    
+
         return <Fragment>
             <script src={cdn('jquery', '3.3.1', 'dist/jquery.min.js')}></script>
             <script src={cdn('moment', '2.22.2', 'min/moment-with-locales.min.js')}></script>
@@ -43,8 +48,9 @@ module.exports = class extends Component {
             <script dangerouslySetInnerHTML={{ __html: embeddedConfig }}></script>
             <script src={url_for('/js/column.js')}></script>
             <Plugins site={site} config={config} page={page} helper={helper} head={false} />
+            <script src={url_for("/js/yuuki/gallery.js")} defer></script>
             <script src={url_for('/js/main.js')} defer></script>
-            {lazyloadScripts}
+            {pjaxScripts}{lazyloadScripts}
         </Fragment>;
     }
 };

--- a/layout/layout.jsx
+++ b/layout/layout.jsx
@@ -15,6 +15,7 @@ module.exports = class extends Component {
         const columnCount = Widgets.getColumnCount(config.widgets);
         const fixedTop = config.navbar.fixed ? ` has-navbar-fixed-top` : ``;
         const waifu =  config.addons.waifuLive2D;
+        const usePjax = config.addons.pjax.enable;
 
         return <html lang={language ? language.substr(0, 2) : ''}>
             <Head site={site} config={config} helper={helper} page={page} />
@@ -24,7 +25,7 @@ module.exports = class extends Component {
 
                 <Navbar config={config} helper={helper} page={page} />
                 <section class="section">
-                    <div class="container">
+                    <div class="container" id="pjax-container">
                         <div class="columns">
                             <div class={classname({
                                 column: true,
@@ -39,10 +40,11 @@ module.exports = class extends Component {
                         </div>
                     </div>
                 </section>
+
                 <Footer config={config} helper={helper} />
                 <Scripts site={site} config={config} helper={helper} page={page} />
                 <Search config={config} helper={helper} />
-
+                {usePjax && <script type="text/javascript" src="/js/yuuki/pjax.js"></script>}
                 <script type="text/javascript" src="/js/imaegoo/imaegoo.js"></script>
                 <script type="text/javascript" src="/js/imaegoo/universe.js"></script>
                 {waifu && <script type="text/javascript" src="/js/live2d/autoload.js"></script>}

--- a/source/js/back_to_top.js
+++ b/source/js/back_to_top.js
@@ -1,4 +1,4 @@
-$(document).ready(() => {
+const backToTopJS = () => {
     const $button = $('#back-to-top');
     const $footer = $('footer.footer');
     const $mainColumn = $('.column-main');
@@ -149,4 +149,6 @@ $(document).ready(() => {
             $('body, html').animate({ scrollTop: 0 }, 400);
         }
     });
-});
+}
+
+$(document).ready(backToTopJS);

--- a/source/js/column.js
+++ b/source/js/column.js
@@ -1,4 +1,4 @@
-(function() {
+function columnJS() {
     function $() {
         return Array.prototype.slice.call(document.querySelectorAll.apply(document, arguments));
     }
@@ -9,4 +9,6 @@
             $('.columns .column-right-shadow')[0].append(child.cloneNode(true));
         }
     }
-}());
+}
+
+columnJS();

--- a/source/js/imaegoo/imaegoo.js
+++ b/source/js/imaegoo/imaegoo.js
@@ -3,18 +3,18 @@
    * 等背景图片加载完成后再显示
    * https://www.imaegoo.com/
    */
-  var dongmanImg = new Image();
-  if (document.body.offsetWidth > 768) {
-    dongmanImg.src = 'https://api.btstu.cn/sjbz/?lx=dongman&format=images&method=pc';
-  } else {
-    dongmanImg.src = 'https://api.btstu.cn/sjbz/?lx=dongman&format=images&method=mobile';
-  }
-  var dongmanInterval = setInterval(function () {
-    if (dongmanImg.complete) {
-      document.body.classList.add('ready');
-      clearInterval(dongmanInterval);
-    }
-  }, 100);
+  // var dongmanImg = new Image();
+  // if (document.body.offsetWidth > 768) {
+  //   dongmanImg.src = 'https://api.btstu.cn/sjbz/?lx=dongman&format=images&method=pc';
+  // } else {
+  //   dongmanImg.src = 'https://api.btstu.cn/sjbz/?lx=dongman&format=images&method=mobile';
+  // }
+  // var dongmanInterval = setInterval(function () {
+  //   if (dongmanImg.complete) {
+  //     document.body.classList.add('ready');
+  //     clearInterval(dongmanInterval);
+  //   }
+  // }, 100);
 
   // /**
   //  * 仿 CSDN 左侧栏吸底效果，设置 position 为 sticky，top 为屏幕高度减去左侧栏高度，比 CSDN 的实现更简洁。

--- a/source/js/imaegoo/night.js
+++ b/source/js/imaegoo/night.js
@@ -1,36 +1,38 @@
-(function() {
-  /**
-   * Icarus 夜间模式 by iMaeGoo
-   * https://www.imaegoo.com/
-   */ 
-  var isNight = localStorage.getItem('night');
-  var nightNav;
+/**
+ * Icarus 夜间模式 by iMaeGoo
+ * https://www.imaegoo.com/
+ */ 
+var isNight = localStorage.getItem('night');
+var nightNav;
 
-  function applyNight(value) {
-      if (value.toString() === 'true') {
-          document.body.classList.remove('light');
-          document.body.classList.add('night');
-      } else {
-          document.body.classList.remove('night');
-          document.body.classList.add('light');
-      }
-  }
+function applyNight(value) {
+    if (value.toString() === 'true') {
+        document.body.classList.remove('light');
+        document.body.classList.add('night');
+    } else {
+        document.body.classList.remove('night');
+        document.body.classList.add('light');
+    }
+}
 
-  function findNightNav() {
-      nightNav = document.getElementById('night-nav');
-      if (!nightNav) {
-          setTimeout(findNightNav, 100);
-      } else {
-          nightNav.addEventListener('click', switchNight);
-      }
-  }
+function findNightNav() {
+    nightNav = document.getElementById('night-nav');
+    if (!nightNav) {
+        setTimeout(findNightNav, 100);
+    } else {
+        nightNav.addEventListener('click', switchNight);
+    }
+}
 
-  function switchNight() {
-      isNight = isNight ? isNight.toString() !== 'true' : true;
-      applyNight(isNight);
-      localStorage.setItem('night', isNight);
-  }
+function switchNight() {
+    isNight = isNight ? isNight.toString() !== 'true' : true;
+    applyNight(isNight);
+    localStorage.setItem('night', isNight);
+}
 
-  findNightNav();
-  isNight && applyNight(isNight);
-}());
+function nightJS() {
+    isNight = localStorage.getItem('night');
+    findNightNav();
+    isNight && applyNight(isNight);
+}
+nightJS();

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -95,7 +95,15 @@ function mainJS($, moment, ClipboardJS, config) {
                 $(this).attr('id', id);
                 $(this).find('figcaption div.level-right').append(button);
             });
-            new ClipboardJS('.highlight .copy'); // eslint-disable-line no-new
+            window.clipInst = new ClipboardJS('.highlight .copy'); // eslint-disable-line no-new
+            clipInst.on('success', function (e) {
+                const { action, text, trigger } = e;
+                console.log('Successfully copy to clipboard!');
+                e.clearSelection();
+            });
+            clipInst.on('error', function (e) {
+                const { action, trigger } = e;
+            });
         }
 
         if (fold) {

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -1,5 +1,6 @@
 /* eslint-disable node/no-unsupported-features/node-builtins */
-(function($, moment, ClipboardJS, config) {
+function mainJS($, moment, ClipboardJS, config) {
+    /*
     $('.article img:not(".not-gallery-item")').each(function() {
         // wrap images with link and add caption if possible
         if ($(this).parent('a').length === 0) {
@@ -19,6 +20,7 @@
         }
         $('.justified-gallery').justifiedGallery();
     }
+    */
 
     if (typeof moment === 'function') {
         $('.article-meta time').each(function() {
@@ -134,4 +136,7 @@
         $mask.on('click', toggleToc);
         $('.navbar-main .catalogue').on('click', toggleToc);
     }
-}(jQuery, window.moment, window.ClipboardJS, window.IcarusThemeSettings));
+}
+$(document).ready(() => {
+    mainJS(jQuery, window.moment, window.ClipboardJS, window.IcarusThemeSettings);
+});

--- a/source/js/yuuki/gallery.js
+++ b/source/js/yuuki/gallery.js
@@ -1,0 +1,24 @@
+const galleryJS = ($) => {
+    $('.article img:not(".not-gallery-item")').each(function() {
+        // wrap images with link and add caption if possible
+        if ($(this).parent('a').length === 0) {
+            $(this).wrap('<a class="gallery-item" href="' + $(this).attr('src') + '"></a>');
+            if (this.alt) {
+                $(this).after('<p class="has-text-centered is-size-6 caption">' + this.alt + '</p>');
+            }
+        }
+    });
+
+    if (typeof $.fn.lightGallery === 'function') {
+        $('.article').lightGallery({ selector: '.gallery-item' });
+    }
+    if (typeof $.fn.justifiedGallery === 'function') {
+        if ($('.justified-gallery > p > .gallery-item').length) {
+            $('.justified-gallery > p > .gallery-item').unwrap();
+        }
+        $('.justified-gallery').justifiedGallery();
+    }
+}
+
+document.addEventListener('DOMContentLoaded', 
+    () => {galleryJS(jQuery);});

--- a/source/js/yuuki/pjax.js
+++ b/source/js/yuuki/pjax.js
@@ -1,9 +1,6 @@
-function busuanziJS() {
+function loadJS() {
     $.getScript("//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js");
-}
-
-const loadJS = () => {
-    busuanziJS();
+    $.getScript("/js/toc.js", () => console.log('pjax: toc.js is reload'));
     backToTopJS();
     galleryJS(jQuery);
     mainJS(jQuery, window.moment, window.ClipboardJS, window.IcarusThemeSettings);
@@ -26,7 +23,21 @@ function removeClipboard() {
     }
 }
 
-function pjaxJS($) {
+function removeToggleToc() {
+    const $toc = $('#toc');
+    const $mask = $('#toc-mask');
+    $mask.remove();
+    $toc.removeClass('is-active');
+    $toc.unbind('click');
+    $('.navbar-main .catalogue').unbind('click');
+}
+
+function removeBinding() {
+    $('#night-nav').unbind('click');
+    $('body').unbind();
+}
+
+function pjaxJS() {
     var pjax = new Pjax({
         elements: 'a[href]:not([href^="#"]):not([href="javascript:void(0)"]):not(.paw-button)',
         selectors: [
@@ -50,9 +61,12 @@ function pjaxJS($) {
 
     document.addEventListener('pjax:send', function () {
         removeClipboard();
+        removeBinding();
+        removeToggleToc();
     });
 
     document.addEventListener('pjax:complete', function () {
+        columnJS();
         loadJS();
         reloadDataPjax();
         nightJS();

--- a/source/js/yuuki/pjax.js
+++ b/source/js/yuuki/pjax.js
@@ -20,6 +20,7 @@ function removeClipboard() {
     if (typeof ClipboardJS !== 'undefined' && (on || fold)) {
         $('figcaption').each(
         function () {$(this).remove();});
+        window.clipInst && window.clipInst.destroy();
     }
 }
 
@@ -34,7 +35,10 @@ function removeToggleToc() {
 
 function removeBinding() {
     $('#night-nav').unbind('click');
-    $('body').unbind();
+    $(window).unbind('resize');
+    $(window).unbind('scroll');
+    $(document).unbind('scroll');
+    $('body').unbind('click');
 }
 
 function pjaxJS() {

--- a/source/js/yuuki/pjax.js
+++ b/source/js/yuuki/pjax.js
@@ -34,7 +34,8 @@ function pjaxJS($) {
             ".column-main",
             "script[data-pjax]",
             "#pjax-container",
-            "#pjax-nav"
+            "#pjax-nav",
+            "#pjax-buttons"
         ],
         switches: {
             ".column-main": function(oldEl, newEl, options) {
@@ -54,6 +55,7 @@ function pjaxJS($) {
     document.addEventListener('pjax:complete', function () {
         loadJS();
         reloadDataPjax();
+        nightJS();
     });
 
     document.addEventListener('pjax:error', function () {

--- a/source/js/yuuki/pjax.js
+++ b/source/js/yuuki/pjax.js
@@ -28,13 +28,13 @@ function removeClipboard() {
 
 function pjaxJS($) {
     var pjax = new Pjax({
-        // elements: "a[data-pjax]",
         elements: 'a[href]:not([href^="#"]):not([href="javascript:void(0)"]):not(.paw-button)',
         selectors: [
             "title",
             ".column-main",
             "script[data-pjax]",
-            "#pjax-container"
+            "#pjax-container",
+            "#pjax-nav"
         ],
         switches: {
             ".column-main": function(oldEl, newEl, options) {

--- a/source/js/yuuki/pjax.js
+++ b/source/js/yuuki/pjax.js
@@ -1,0 +1,64 @@
+function busuanziJS() {
+    $.getScript("//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js");
+}
+
+const loadJS = () => {
+    busuanziJS();
+    backToTopJS();
+    galleryJS(jQuery);
+    mainJS(jQuery, window.moment, window.ClipboardJS, window.IcarusThemeSettings);
+}
+
+function reloadDataPjax() {
+    $('script[data-pjax], .pjax-reload script')
+    .each(function () {
+        $(this).parent().append($(this).remove());
+    });
+}
+
+function removeClipboard() {
+    const ClipboardJS = window.IcarusThemeSettings;
+    const on = window.IcarusThemeSettings.article.highlight.clipboard;
+    const fold = window.IcarusThemeSettings.article.highlight.fold.trim();
+    if (typeof ClipboardJS !== 'undefined' && (on || fold)) {
+        $('figcaption').each(
+        function () {$(this).remove();});
+    }
+}
+
+function pjaxJS($) {
+    var pjax = new Pjax({
+        // elements: "a[data-pjax]",
+        elements: 'a[href]:not([href^="#"]):not([href="javascript:void(0)"]):not(.paw-button)',
+        selectors: [
+            "title",
+            ".column-main",
+            "script[data-pjax]",
+            "#pjax-container"
+        ],
+        switches: {
+            ".column-main": function(oldEl, newEl, options) {
+                oldEl.outerHTML = newEl.outerHTML;
+                this.onSwitch();
+            },
+        },
+        cacheBust: false,
+        scrollRestoration: true,
+        debug: false
+    })
+
+    document.addEventListener('pjax:send', function () {
+        removeClipboard();
+    });
+
+    document.addEventListener('pjax:complete', function () {
+        loadJS();
+        reloadDataPjax();
+    });
+
+    document.addEventListener('pjax:error', function () {
+        console.log("Pjax loading error is occurred.");
+    });
+}
+
+document.addEventListener("DOMContentLoaded", pjaxJS);


### PR DESCRIPTION
Now Pjax is working properly in tablet view and mobile view :-)

## alter

- add a pjax selector `#pjax-buttons` to show toc button when page reloads.
- overload `column.js` to generate toc in non-wide views when pjax fetched.
- try to resolve event-binding at copy buttons by destroying clipboard instance when `pjax:send`.

## note

Test: buttons in `#pjax-buttons` seem to work properly.

At last, I fixed this at the last day of 2021 winter vacation 👍 