### PR TITLE
Fix pjax toc

### DIFF
--- a/layout/common/navbar.jsx
+++ b/layout/common/navbar.jsx
@@ -58,7 +58,7 @@ class Navbar extends Component {
                             return <a class={classname({ 'navbar-item': true, 'is-active': item.active })} href={item.url}>{name}</a>;
                         })}
                     </div> : null}
-                    <div class="navbar-end">
+                    <div class="navbar-end" id="pjax-buttons">
                         {showToc ? <a class="navbar-item is-hidden-tablet catalogue" title={tocTitle} href="javascript:;">
                             <i class="fas fa-list-ul"></i>
                         </a> : null}

--- a/source/js/column.js
+++ b/source/js/column.js
@@ -1,4 +1,4 @@
-(function() {
+function columnJS() {
     function $() {
         return Array.prototype.slice.call(document.querySelectorAll.apply(document, arguments));
     }
@@ -9,4 +9,6 @@
             $('.columns .column-right-shadow')[0].append(child.cloneNode(true));
         }
     }
-}());
+}
+
+columnJS();

--- a/source/js/imaegoo/night.js
+++ b/source/js/imaegoo/night.js
@@ -1,36 +1,38 @@
-(function() {
-  /**
-   * Icarus 夜间模式 by iMaeGoo
-   * https://www.imaegoo.com/
-   */ 
-  var isNight = localStorage.getItem('night');
-  var nightNav;
+/**
+ * Icarus 夜间模式 by iMaeGoo
+ * https://www.imaegoo.com/
+ */ 
+var isNight = localStorage.getItem('night');
+var nightNav;
 
-  function applyNight(value) {
-      if (value.toString() === 'true') {
-          document.body.classList.remove('light');
-          document.body.classList.add('night');
-      } else {
-          document.body.classList.remove('night');
-          document.body.classList.add('light');
-      }
-  }
+function applyNight(value) {
+    if (value.toString() === 'true') {
+        document.body.classList.remove('light');
+        document.body.classList.add('night');
+    } else {
+        document.body.classList.remove('night');
+        document.body.classList.add('light');
+    }
+}
 
-  function findNightNav() {
-      nightNav = document.getElementById('night-nav');
-      if (!nightNav) {
-          setTimeout(findNightNav, 100);
-      } else {
-          nightNav.addEventListener('click', switchNight);
-      }
-  }
+function findNightNav() {
+    nightNav = document.getElementById('night-nav');
+    if (!nightNav) {
+        setTimeout(findNightNav, 100);
+    } else {
+        nightNav.addEventListener('click', switchNight);
+    }
+}
 
-  function switchNight() {
-      isNight = isNight ? isNight.toString() !== 'true' : true;
-      applyNight(isNight);
-      localStorage.setItem('night', isNight);
-  }
+function switchNight() {
+    isNight = isNight ? isNight.toString() !== 'true' : true;
+    applyNight(isNight);
+    localStorage.setItem('night', isNight);
+}
 
-  findNightNav();
-  isNight && applyNight(isNight);
-}());
+function nightJS() {
+    isNight = localStorage.getItem('night');
+    findNightNav();
+    isNight && applyNight(isNight);
+}
+nightJS();

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -95,7 +95,15 @@ function mainJS($, moment, ClipboardJS, config) {
                 $(this).attr('id', id);
                 $(this).find('figcaption div.level-right').append(button);
             });
-            new ClipboardJS('.highlight .copy'); // eslint-disable-line no-new
+            window.clipInst = new ClipboardJS('.highlight .copy'); // eslint-disable-line no-new
+            clipInst.on('success', function (e) {
+                const { action, text, trigger } = e;
+                console.log('Successfully copy to clipboard!');
+                e.clearSelection();
+            });
+            clipInst.on('error', function (e) {
+                const { action, trigger } = e;
+            });
         }
 
         if (fold) {

--- a/source/js/yuuki/pjax.js
+++ b/source/js/yuuki/pjax.js
@@ -1,9 +1,6 @@
-function busuanziJS() {
+function loadJS() {
     $.getScript("//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js");
-}
-
-const loadJS = () => {
-    busuanziJS();
+    $.getScript("/js/toc.js", () => console.log('pjax: toc.js is reload'));
     backToTopJS();
     galleryJS(jQuery);
     mainJS(jQuery, window.moment, window.ClipboardJS, window.IcarusThemeSettings);
@@ -26,7 +23,21 @@ function removeClipboard() {
     }
 }
 
-function pjaxJS($) {
+function removeToggleToc() {
+    const $toc = $('#toc');
+    const $mask = $('#toc-mask');
+    $mask.remove();
+    $toc.removeClass('is-active');
+    $toc.unbind('click');
+    $('.navbar-main .catalogue').unbind('click');
+}
+
+function removeBinding() {
+    $('#night-nav').unbind('click');
+    $('body').unbind();
+}
+
+function pjaxJS() {
     var pjax = new Pjax({
         elements: 'a[href]:not([href^="#"]):not([href="javascript:void(0)"]):not(.paw-button)',
         selectors: [
@@ -50,9 +61,12 @@ function pjaxJS($) {
 
     document.addEventListener('pjax:send', function () {
         removeClipboard();
+        removeBinding();
+        removeToggleToc();
     });
 
     document.addEventListener('pjax:complete', function () {
+        columnJS();
         loadJS();
         reloadDataPjax();
         nightJS();

--- a/source/js/yuuki/pjax.js
+++ b/source/js/yuuki/pjax.js
@@ -20,6 +20,7 @@ function removeClipboard() {
     if (typeof ClipboardJS !== 'undefined' && (on || fold)) {
         $('figcaption').each(
         function () {$(this).remove();});
+        window.clipInst && window.clipInst.destroy();
     }
 }
 
@@ -34,7 +35,10 @@ function removeToggleToc() {
 
 function removeBinding() {
     $('#night-nav').unbind('click');
-    $('body').unbind();
+    $(window).unbind('resize');
+    $(window).unbind('scroll');
+    $(document).unbind('scroll');
+    $('body').unbind('click');
 }
 
 function pjaxJS() {

--- a/source/js/yuuki/pjax.js
+++ b/source/js/yuuki/pjax.js
@@ -34,7 +34,8 @@ function pjaxJS($) {
             ".column-main",
             "script[data-pjax]",
             "#pjax-container",
-            "#pjax-nav"
+            "#pjax-nav",
+            "#pjax-buttons"
         ],
         switches: {
             ".column-main": function(oldEl, newEl, options) {
@@ -54,6 +55,7 @@ function pjaxJS($) {
     document.addEventListener('pjax:complete', function () {
         loadJS();
         reloadDataPjax();
+        nightJS();
     });
 
     document.addEventListener('pjax:error', function () {


### PR DESCRIPTION
Re-do: this time it will be merged into a correct branch (

## modify

- add a pjax selector `#pjax-buttons` to show toc button when page reloads.
- overload `column.js` to generate toc in non-wide views when pjax fetched.
- try to resolve event-binding at copy buttons by destroying clipboard instance when `pjax:send`.

## refer

[the origin PR](https://github.com/YukiNoUta/hexo-theme-icarus/pull/6)